### PR TITLE
Update Longhorn replica counts and add Metallb namespace configuration

### DIFF
--- a/infrastructure/skywalker/longhorn/kustomization.yaml
+++ b/infrastructure/skywalker/longhorn/kustomization.yaml
@@ -13,9 +13,9 @@ patchesStrategicMerge:
     spec:
       values:
         persistence:
-          defaultClassReplicaCount: 2
+          defaultClassReplicaCount: 3
         defaultSettings:
-          defaultreplicaCount: 2
+          defaultreplicaCount: 3
           defaultDataPath: /var/mnt/longhorn
           storageReservedPercentageForDefaultDisk: 5
   - |-

--- a/infrastructure/skywalker/metallb/kustomization.yaml
+++ b/infrastructure/skywalker/metallb/kustomization.yaml
@@ -3,3 +3,15 @@ kind: Kustomization
 resources:
   - ../../base/metallb
   - metallb-config.yaml
+
+
+patchesStrategicMerge:
+  - |-
+    apiVersion: v1
+    kind: Namespace
+    metadata:
+      name: metallb-system
+      labels:
+        pod-security.kubernetes.io/enforce: privileged
+        pod-security.kubernetes.io/audit: privileged
+        pod-security.kubernetes.io/warn: privileged


### PR DESCRIPTION
This pull request updates configuration settings for both Longhorn and MetalLB in the Skywalker infrastructure to improve storage redundancy and enhance Kubernetes namespace security labeling.

**Longhorn storage configuration:**

* Increased the default replica count for Longhorn volumes from 2 to 3 in both `defaultClassReplicaCount` and `defaultreplicaCount`, improving data redundancy and fault tolerance. (`infrastructure/skywalker/longhorn/kustomization.yaml`)

**MetalLB namespace security:**

* Added a strategic merge patch to label the `metallb-system` namespace with Kubernetes Pod Security admission labels set to `privileged`, ensuring MetalLB can run with the necessary permissions. (`infrastructure/skywalker/metallb/kustomization.yaml`)