### PR TITLE
Replace deprecated patchesStrategicMerge with patches

### DIFF
--- a/apps/skywalker/authentik/hr-patch.yaml
+++ b/apps/skywalker/authentik/hr-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: authentik
+  namespace: authentik
+spec:
+  valuesFrom:
+    - kind: ConfigMap
+      name: authentik-values
+      valuesKey: values.yaml

--- a/apps/skywalker/authentik/kustomization.yaml
+++ b/apps/skywalker/authentik/kustomization.yaml
@@ -13,15 +13,5 @@ configMapGenerator:
 configurations:
   - kustomizeconfig.yaml
 
-patchesStrategicMerge:
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    metadata:
-      name: authentik
-      namespace: authentik
-    spec:
-      valuesFrom:
-        - kind: ConfigMap
-          name: authentik-values
-          valuesKey: values.yaml
+patches:
+  - path: hr-patch.yaml

--- a/infrastructure/skywalker/cert-manager/certificates/certificate-reflector-patch.yaml
+++ b/infrastructure/skywalker/cert-manager/certificates/certificate-reflector-patch.yaml
@@ -1,0 +1,11 @@
+apiVersion: cert-manager.io/v1
+kind: Certificate
+metadata:
+  name: plutolab-live-tls
+  namespace: traefik
+spec:
+  secretTemplate:
+    annotations:
+      reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
+      reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
+      reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "actual-budget,authentik,it-tools"

--- a/infrastructure/skywalker/cert-manager/certificates/kustomization.yaml
+++ b/infrastructure/skywalker/cert-manager/certificates/kustomization.yaml
@@ -3,16 +3,5 @@ kind: Kustomization
 resources:
   - ../../../base/cert-manager/certificates
 
-patchesStrategicMerge:
-  - |-
-    apiVersion: cert-manager.io/v1
-    kind: Certificate
-    metadata:
-      name: plutolab-live-tls
-      namespace: traefik
-    spec:
-      secretTemplate:
-        annotations:
-          reflector.v1.k8s.emberstack.com/reflection-allowed: "true"
-          reflector.v1.k8s.emberstack.com/reflection-auto-enabled: "true"
-          reflector.v1.k8s.emberstack.com/reflection-allowed-namespaces: "actual-budget,authentik,it-tools"
+patches:
+  - path: certificate-reflector-patch.yaml

--- a/infrastructure/skywalker/longhorn/hr-patch.yaml
+++ b/infrastructure/skywalker/longhorn/hr-patch.yaml
@@ -1,0 +1,13 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: longhorn
+  namespace: longhorn-system
+spec:
+  values:
+    persistence:
+      defaultClassReplicaCount: 3
+    defaultSettings:
+      defaultreplicaCount: 3
+      defaultDataPath: /var/mnt/longhorn
+      storageReservedPercentageForDefaultDisk: 5

--- a/infrastructure/skywalker/longhorn/kustomization.yaml
+++ b/infrastructure/skywalker/longhorn/kustomization.yaml
@@ -2,28 +2,7 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 resources:
   - ../../base/longhorn
-  
-patchesStrategicMerge:
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
-    kind: HelmRelease
-    metadata:
-      name: longhorn
-      namespace: longhorn-system
-    spec:
-      values:
-        persistence:
-          defaultClassReplicaCount: 3
-        defaultSettings:
-          defaultreplicaCount: 3
-          defaultDataPath: /var/mnt/longhorn
-          storageReservedPercentageForDefaultDisk: 5
-  - |-
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: longhorn-system
-      labels:
-        pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/audit: privileged
-        pod-security.kubernetes.io/warn: privileged
+
+patches:
+  - path: namespace-patch.yaml
+  - path: hr-patch.yaml

--- a/infrastructure/skywalker/longhorn/namespace-patch.yaml
+++ b/infrastructure/skywalker/longhorn/namespace-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: longhorn-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/infrastructure/skywalker/metallb/kustomization.yaml
+++ b/infrastructure/skywalker/metallb/kustomization.yaml
@@ -4,14 +4,5 @@ resources:
   - ../../base/metallb
   - metallb-config.yaml
 
-
-patchesStrategicMerge:
-  - |-
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: metallb-system
-      labels:
-        pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/audit: privileged
-        pod-security.kubernetes.io/warn: privileged
+patches:
+  - path: namespace-patch.yaml

--- a/infrastructure/skywalker/metallb/namespace-patch.yaml
+++ b/infrastructure/skywalker/metallb/namespace-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: metallb-system
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/infrastructure/skywalker/traefik/hr-patch.yaml
+++ b/infrastructure/skywalker/traefik/hr-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: traefik
+  namespace: traefik
+spec:
+  valuesFrom:
+    - kind: ConfigMap
+      name: traefik-values
+      valuesKey: values.yaml

--- a/infrastructure/skywalker/traefik/kustomization.yaml
+++ b/infrastructure/skywalker/traefik/kustomization.yaml
@@ -12,15 +12,5 @@ configMapGenerator:
 configurations:
   - kustomizeconfig.yaml
 
-patchesStrategicMerge:
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
-    kind: HelmRelease
-    metadata:
-      name: traefik
-      namespace: traefik
-    spec:
-      valuesFrom:
-        - kind: ConfigMap
-          name: traefik-values
-          valuesKey: values.yaml
+patches:
+  - path: hr-patch.yaml

--- a/monitoring/skywalker/kube-prometheus-stack/hr-patch.yaml
+++ b/monitoring/skywalker/kube-prometheus-stack/hr-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2beta1
+kind: HelmRelease
+metadata:
+  name: kube-prometheus
+  namespace: monitoring
+spec:
+  valuesFrom:
+    - kind: ConfigMap
+      name: kube-prometheus-values
+      valuesKey: values.yaml

--- a/monitoring/skywalker/kube-prometheus-stack/kustomization.yaml
+++ b/monitoring/skywalker/kube-prometheus-stack/kustomization.yaml
@@ -12,24 +12,6 @@ configMapGenerator:
 configurations:
   - kustomizeconfig.yaml
 
-patchesStrategicMerge:
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2beta1
-    kind: HelmRelease
-    metadata:
-      name: kube-prometheus
-      namespace: monitoring
-    spec:
-      valuesFrom:
-        - kind: ConfigMap
-          name: kube-prometheus-values
-          valuesKey: values.yaml
-  - |-
-    apiVersion: v1
-    kind: Namespace
-    metadata:
-      name: monitoring
-      labels:
-        pod-security.kubernetes.io/enforce: privileged
-        pod-security.kubernetes.io/audit: privileged
-        pod-security.kubernetes.io/warn: privileged
+patches:
+  - path: namespace-patch.yaml
+  - path: hr-patch.yaml

--- a/monitoring/skywalker/kube-prometheus-stack/namespace-patch.yaml
+++ b/monitoring/skywalker/kube-prometheus-stack/namespace-patch.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: monitoring
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/warn: privileged

--- a/monitoring/skywalker/loki/hr-patch.yaml
+++ b/monitoring/skywalker/loki/hr-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: loki
+  namespace: monitoring
+spec:
+  valuesFrom:
+    - kind: ConfigMap
+      name: loki-values
+      valuesKey: values.yaml

--- a/monitoring/skywalker/loki/kustomization.yaml
+++ b/monitoring/skywalker/loki/kustomization.yaml
@@ -12,15 +12,5 @@ configMapGenerator:
 configurations:
   - kustomizeconfig.yaml
 
-patchesStrategicMerge:
-  - |-
-    apiVersion: helm.toolkit.fluxcd.io/v2
-    kind: HelmRelease
-    metadata:
-      name: loki
-      namespace: monitoring
-    spec:
-      valuesFrom:
-        - kind: ConfigMap
-          name: loki-values
-          valuesKey: values.yaml
+patches:
+  - path: hr-patch.yaml


### PR DESCRIPTION
This pull request refactors how Kubernetes patches are managed in the repository, moving from inline YAML patches defined under `patchesStrategicMerge` to using external patch files referenced via the `patches` field in Kustomization files. This change improves maintainability and clarity by separating patch content from Kustomization configuration. Additionally, several new patch files are introduced or updated for HelmRelease and Namespace resources across multiple components.

Key changes include:

**Refactoring patch management to use external files:**

* Replaced all inline patches defined under `patchesStrategicMerge` with references to external YAML patch files using the `patches` field in Kustomization files for `authentik`, `traefik`, `longhorn`, `metallb`, `kube-prometheus-stack`, and `loki` components. [[1]](diffhunk://#diff-a45709fb42ab2a54ba3fbb94ec28eb9b3600bc800aa22652b8455d0046f93b65L16-R17) [[2]](diffhunk://#diff-874eeb10cff60e8aa8eec75d7e48c6b415e58a360cc9e1dfad2d23d51eaf6ecfL15-R16) [[3]](diffhunk://#diff-72dc4e83720723f64cbf6e4738fb897e335f4fad6b2e4c781e5b4bd92214caa5L6-R8) [[4]](diffhunk://#diff-d6df5fec0c49133bd2b8e37b7e414c503d60df40ee63d7d0bd9b776b83fe892bL7-R8) [[5]](diffhunk://#diff-4134e1520260dd30a683b91886bab7be605f9b3ceb7ad251df4a0b5e747ca749L15-R17) [[6]](diffhunk://#diff-9b37343c13c2cfb6912705ef8fedd8537c4705d80d799305c2097ccb7c173375L15-R16) [[7]](diffhunk://#diff-587b2d50286d2d1b6fca858e2538ee8a3bb49b324f54ff70388184e73e431995L6-R7)

**Addition of new patch files for HelmRelease and Namespace resources:**

* Added new patch files such as `hr-patch.yaml` and `namespace-patch.yaml` for various components, defining HelmRelease and Namespace configurations separately for easier management. [[1]](diffhunk://#diff-ed855402bb55793cb101c3187aaac83e5265ea53e1a5a3cdca8ad312bb78c123R1-R10) [[2]](diffhunk://#diff-200fa3d9958d66a5fd6cedce8c8dc9f1531282a5402d2bc6b401024d3be85568R1-R10) [[3]](diffhunk://#diff-c76637b43a0ee1a66e574f72392d03b326816333a91d6ac29dea8db3a2f28c5cR1-R13) [[4]](diffhunk://#diff-60e4e3878dce6055600a6859e52d9d9c6400189627322a189a943a1b2d3f4f02R1-R8) [[5]](diffhunk://#diff-87d3b2afe976205b515c06f0c663c0a4d627a292d2b0080891249dbd1dc58e09R1-R8) [[6]](diffhunk://#diff-ed753e49e843ab848c6cddfd6a18de3284c126ff45ed838fc08f0b57c98cfa4bR1-R10) [[7]](diffhunk://#diff-91b631244506541351de70d392e6ee63ea52d4cb4be394c1cf4b4937e312384eR1-R8) [[8]](diffhunk://#diff-b9844563baee2435801e6df4d182ca8ff661eb112087682ce13b3f427906b8a9R1-R10) [[9]](diffhunk://#diff-9ab88b8e4e472ae7044bfa99148e6a00b31ef91aacfc790842b52f53f4148b30R1-R11)

**Improved clarity and maintainability:**

* By moving patch content to separate files, the configuration is now cleaner and easier to update or review, reducing the risk of errors and making future changes more straightforward. (all references above)